### PR TITLE
Switch WISP endpoint to faster wss://wisp.rhw.one

### DIFF
--- a/app/uv.html
+++ b/app/uv.html
@@ -299,7 +299,7 @@
 
         // actual uv handling
         const connection = new BareMux.BareMuxConnection("/baremux/worker.js")
-        const wispUrl = "wss://webmath.help/wisp/" // terbium's wisp
+        const wispUrl = "wss://wisp.rhw.one" // rhw wisp, super speedy
         const bareUrl = "https://useclassplay.vercel.app/fq/" // old site i have
 
         connection.setTransport("/libcurl/index.mjs", [{ websocket: wispUrl }])


### PR DESCRIPTION
I changed it to `wss://wisp.rhw.one` which is faster than Terbium